### PR TITLE
Update error message using lowercase b instead

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ async fn try_connect(host: String, port: u32, timeout: Duration) -> io::Result<u
             Err(e) => match e.kind() {
                 ErrorKind::Other => {
                     eprintln!("{:?}", e); // in case we get too many open files
-                    panic!("Too many open files. Please reduce batch size. The default is 5000. Try -B 2500.");
+                    panic!("Too many open files. Please reduce batch size. The default is 5000. Try -b 2500.");
                     Err(e)
                 }
                 _ => Err(io::Error::new(io::ErrorKind::Other, e.to_string())),


### PR DESCRIPTION
-B is confusing you can't use uppercase b as argument