### PR TITLE
Wait for child nmap process to exit completely

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -185,10 +185,12 @@ fn main() {
     let vec = command_list.collect::<Vec<&str>>();
 
     // Runs the nmap command and spawns it as a process.
-    Command::new("nmap")
+    let mut child = Command::new("nmap")
         .args(&vec)
         .spawn()
-        .expect("failed to execute process");
+        .expect("failed to execute nmap process");
+
+    child.wait().expect("failed to wait on nmap process");
 }
 
 pub async fn run_batched(


### PR DESCRIPTION
In certain OSs a process might become a zombie if we do not explicitlywait for it to finish. This addresses the child not being killed when a parent receives a CTRL+C.

Fixes https://github.com/brandonskerritt/RustScan/issues/14