### PR TITLE
Add -Pn to the Nmap arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ fn main() {
         exit(1);
     }
 
-    let string_format = format!("{} {} {} {} {}", command_run, "-vvv", "-p", &ports_str, ip);
+    let string_format = format!("{} {} {} {} {} {}", command_run, "-Pn", "-vvv", "-p", &ports_str, ip);
     let command_list = string_format.split_whitespace();
     let vec = command_list.collect::<Vec<&str>>();
 


### PR DESCRIPTION
This prevents Nmap from taking extra time doing its initial host detection when we already know ports are up.
Not having this flag occasionally causes hosts to not be scanned as well.